### PR TITLE
Fix typo in notification message

### DIFF
--- a/CAT_pack/prepare.py
+++ b/CAT_pack/prepare.py
@@ -293,7 +293,7 @@ def make_fastaid2LCAtaxid_file(taxonomy_folder,
 
     message = ('Done! File {0} is created. '
                '{1} of {2} headers ({3:.1f}%) corrected. Please wait '
-               'patiently for Python to collect carbage.'
+               'patiently for Python to collect garbage.'
                ''.format(fastaid2LCAtaxid_file,
                          corrected,
                          total,


### PR DESCRIPTION
'garbage' in the message 'Please wait patiently for Python to collect carbage.' (displayed after making the `nr.fastaid2LCAtaxid`) had a typo.