### PR TITLE
add catch for lineage with only 2 taxids

### DIFF
--- a/CAT_pack/tax.py
+++ b/CAT_pack/tax.py
@@ -133,6 +133,9 @@ def find_questionable_taxids(lineage, taxids_with_multiple_offspring):
     if lineage == ['1']:
         return questionable_taxids
     
+    if len(lineage) == 2 and lineage[1:] == ['1']:
+        return questionable_taxids 
+    
     for (i, taxid) in enumerate(lineage):
         taxid_parent = lineage[i + 1]
         if taxid_parent in taxids_with_multiple_offspring:


### PR DESCRIPTION
Lineage with 2 taxids causes IndexError with enumerate() so adding additional check to catch those instances and end the processing in advance. Fixes all of the problems in #32 .