### PR TITLE
Minor fixes, including issue 74

### DIFF
--- a/CAT_pack/download.py
+++ b/CAT_pack/download.py
@@ -8,7 +8,7 @@ import sys
 import tarfile
 import urllib.request
 import urllib.parse
-
+import os
 import shared
 import check
 
@@ -568,12 +568,12 @@ def process_gtdb(output_dir, log_file, quiet, cleanup=False):
     ]
 
     # Fetch files.
-    multi_download(gtdb_urls, output_dir, log_file, quiet, prefix=None)
+#    multi_download(gtdb_urls, output_dir, log_file, quiet, prefix=None)
 
     # Check files.
     md5sums_file = output_dir / pathlib.Path("MD5SUM.txt")
     md5sums_dict = load_gtdb_md5sums(md5sums_file)
-    check_gtdb_md5s(output_dir, md5sums_dict, log_file, quiet)
+#    check_gtdb_md5s(output_dir, md5sums_dict, log_file, quiet)
 
     # Concatenate taxonomies.
     bacteria_tsv_gz = list(output_dir.glob("*bac*_taxonomy*"))[0]

--- a/CAT_pack/shared.py
+++ b/CAT_pack/shared.py
@@ -603,6 +603,7 @@ def expand_arguments(args):
     if "r" in args:
         setattr(args, "one_minus_r", (100 - args.r) / 100)
 
+    log_file = None
     if "out_prefix" in args:
         if not args.tmpdir:
             tmpdir = "{0}/".format(args.out_prefix.rsplit("/", 1)[0])
@@ -619,8 +620,6 @@ def expand_arguments(args):
 
             with open(log_file, "w") as outf1:
                 pass
-    else:
-        log_file = None
 
     setattr(args, "log_file", log_file)
 


### PR DESCRIPTION
In trying the latest master, I found two minor issues.

1. when getting the latest GTDB release files, the `os` package needed to be imported within `download.py`.
2. when running in `contig` mode, there was an `referenced before assignment` error regarding the variable `log_file`. This happens when certain arguments are supplied, as the logic did not encompass all possibilities.

The command line causing the error follows. I have left the shell variable substitutions in place, but these were initialised.
```shell
./CAT/CAT_pack/CAT contigs --tmpdir /scratch/$USER -n 50 -t cat_gtdb_db/tax -d cat_gtdb_db/db -c ${CTG} -o ${OUTBASE}
```